### PR TITLE
fix: forward accessibility props to AppImage fallback views

### DIFF
--- a/src/components/AppImage.tsx
+++ b/src/components/AppImage.tsx
@@ -48,13 +48,27 @@ export default function AppImage({
   fallbackTextStyle,
   contentFit = "cover",
   style,
+  // Destructure accessibility props so fallback Views stay labeled.
+  // expo-image accepts these via ...rest, but the fallback paths render
+  // plain Views which need them explicitly to avoid regressing a11y.
+  accessibilityLabel,
+  accessibilityRole,
+  accessibilityHint,
+  accessible,
   ...rest
 }: AppImageProps) {
+  const a11yProps = {
+    accessibilityLabel,
+    accessibilityRole,
+    accessibilityHint,
+    accessible,
+  };
+
   // Missing source — render letter fallback or nothing
   if (!source) {
     if (fallbackText) {
       return (
-        <View style={[styles.fallback, style, fallbackStyle]}>
+        <View style={[styles.fallback, style, fallbackStyle]} {...a11yProps}>
           <Text style={[styles.fallbackText, fallbackTextStyle]}>
             {fallbackText}
           </Text>
@@ -63,7 +77,7 @@ export default function AppImage({
     }
     // No source and no fallback text — render empty View so parent
     // layout isn't disrupted (maintains the image's space)
-    return <View style={style} />;
+    return <View style={style} {...a11yProps} />;
   }
 
   // Source exists — render expo-image with defaults.
@@ -75,6 +89,7 @@ export default function AppImage({
       contentFit={contentFit}
       placeholder={{ blurhash: DEFAULT_BLURHASH }}
       transition={IMAGE_TRANSITION}
+      {...a11yProps}
       {...rest}
     />
   );

--- a/src/components/__tests__/AppImage.test.tsx
+++ b/src/components/__tests__/AppImage.test.tsx
@@ -134,4 +134,29 @@ describe("AppImage", () => {
 
     expect(screen.getByLabelText("Wool fabric swatch")).toBeTruthy();
   });
+
+  it("passes accessibilityLabel to fallback View when source is null with fallbackText", () => {
+    render(
+      <AppImage
+        source={null}
+        fallbackText="W"
+        accessibilityLabel="Wool fabric swatch"
+        style={{ width: 100, height: 100 }}
+      />,
+    );
+
+    expect(screen.getByLabelText("Wool fabric swatch")).toBeTruthy();
+  });
+
+  it("passes accessibilityLabel to empty fallback View when source is null without fallbackText", () => {
+    render(
+      <AppImage
+        source={null}
+        accessibilityLabel="Wool fabric swatch"
+        style={{ width: 100, height: 100 }}
+      />,
+    );
+
+    expect(screen.getByLabelText("Wool fabric swatch")).toBeTruthy();
+  });
 });


### PR DESCRIPTION
## Summary
- `AppImage` previously forwarded accessibility props (`accessibilityLabel`, `accessibilityRole`, `accessibilityHint`, `accessible`) to the `expo-image` happy path via `...rest`, but the two fallback `<View>` branches (letter fallback and empty spacer) silently dropped them.
- Destructure those props at the top of the component and apply them explicitly to all three render paths so null-source renders stay labeled for screen readers.
- Adds two tests covering each fallback branch.

## Test plan
- [x] `npm test -- AppImage` passes (existing + 2 new cases)
- [ ] Manual VoiceOver check on a screen rendering a fabric with no `image_url` — letter fallback should announce its label