### PR TITLE
feat: enrich WhatsApp support messages with order/product context (#48)

### DIFF
--- a/app/(app)/(tabs)/(products)/configurator.tsx
+++ b/app/(app)/(tabs)/(products)/configurator.tsx
@@ -417,11 +417,16 @@ export default function ConfiguratorScreen() {
         />
       </View>
 
-      {/* WhatsApp support FAB — pre-filled with the product being configured */}
+      {/* WhatsApp support FAB — pre-filled with the product being configured.
+        Fabric and step label are included when available so the tailor sees
+        exactly where the customer is in the flow. stepLabels reuses the
+        same array driving the progress bar above. */}
       <SupportFAB
         context={{
           screen: "configurator",
           productName: product?.name ?? "product",
+          fabricName: fabric?.name,
+          stepLabel: stepLabels[currentStep],
         }}
       />
     </View>

--- a/app/(app)/(tabs)/(profile)/order-detail.tsx
+++ b/app/(app)/(tabs)/(profile)/order-detail.tsx
@@ -164,12 +164,18 @@ export default function OrderDetailScreen() {
           Order ref: {order.id.slice(0, 8).toUpperCase()}
         </Text>
       </ScrollView>
-      {/* WhatsApp support FAB — pre-filled with order context */}
+      {/* WhatsApp support FAB — pre-filled with order context.
+        Pass raw join values (not the "Custom Item" UI fallback) so the
+        message omits the descriptor cleanly when the join returned no
+        product/fabric, rather than leaking placeholder strings. */}
       <SupportFAB
         context={{
           screen: "order-detail",
           orderId: order.id.slice(0, 8).toUpperCase(),
           orderStatus: order.current_status,
+          productName: order.products?.name,
+          fabricName: order.fabrics?.name,
+          finalPriceCents: order.final_price,
         }}
       />
     </View>

--- a/src/lib/__tests__/support.test.ts
+++ b/src/lib/__tests__/support.test.ts
@@ -3,6 +3,10 @@
  *
  * Tests the message prefill logic for each screen context. Linking calls
  * are mocked since we can't actually open WhatsApp in a test environment.
+ *
+ * Assertions use encoded substring matching (`stringContaining`) rather
+ * than full URL equality so the tests stay robust to incidental encoding
+ * changes (e.g. whether spaces become `%20` or `+`).
  */
 
 import { Linking, Alert } from "react-native";
@@ -27,53 +31,182 @@ beforeEach(() => {
     EXPO_PUBLIC_SUPPORT_WHATSAPP: "911234567890",
   };
   jest.clearAllMocks();
+  (Linking.canOpenURL as jest.Mock).mockResolvedValue(true);
 });
 afterAll(() => {
   process.env = ORIGINAL_ENV;
 });
 
-describe("openWhatsAppSupport", () => {
-  it("opens WhatsApp with configurator context", async () => {
-    (Linking.canOpenURL as jest.Mock).mockResolvedValue(true);
+/** Helper — pull the URL from the most recent openURL call. */
+function lastUrl(): string {
+  const calls = (Linking.openURL as jest.Mock).mock.calls;
+  return calls[calls.length - 1][0] as string;
+}
 
+describe("openWhatsAppSupport — configurator", () => {
+  it("falls back to the minimal message when no enrichment is provided", async () => {
     await openWhatsAppSupport({
       screen: "configurator",
       productName: "Classic Suit",
     });
-
-    expect(Linking.openURL).toHaveBeenCalledWith(
-      expect.stringContaining("wa.me/"),
-    );
-    expect(Linking.openURL).toHaveBeenCalledWith(
-      expect.stringContaining("configuring%20my%20Classic%20Suit"),
-    );
+    const url = lastUrl();
+    expect(url).toContain("wa.me/");
+    expect(url).toContain("configuring%20my%20Classic%20Suit");
+    // No parenthetical clause when neither enrichment field is present
+    expect(url).not.toContain("Fabric");
+    expect(url).not.toContain("Step");
   });
 
-  it("opens WhatsApp with order-detail context", async () => {
-    (Linking.canOpenURL as jest.Mock).mockResolvedValue(true);
+  it("includes Fabric and Step when both enrichments are present", async () => {
+    await openWhatsAppSupport({
+      screen: "configurator",
+      productName: "Classic Suit",
+      fabricName: "Black Wool Crepe",
+      stepLabel: "Collar Style",
+    });
+    const url = lastUrl();
+    expect(url).toContain("Fabric%3A%20Black%20Wool%20Crepe");
+    expect(url).toContain("Step%3A%20Collar%20Style");
+  });
 
+  it("includes only Fabric when stepLabel is absent", async () => {
+    await openWhatsAppSupport({
+      screen: "configurator",
+      productName: "Classic Suit",
+      fabricName: "Black Wool Crepe",
+    });
+    const url = lastUrl();
+    expect(url).toContain("Fabric%3A%20Black%20Wool%20Crepe");
+    expect(url).not.toContain("Step");
+  });
+
+  it("includes only Step when fabricName is absent", async () => {
+    await openWhatsAppSupport({
+      screen: "configurator",
+      productName: "Classic Suit",
+      stepLabel: "Collar Style",
+    });
+    const url = lastUrl();
+    expect(url).toContain("Step%3A%20Collar%20Style");
+    expect(url).not.toContain("Fabric");
+  });
+
+  it("emits Step: Review on the review step", async () => {
+    await openWhatsAppSupport({
+      screen: "configurator",
+      productName: "Classic Suit",
+      stepLabel: "Review",
+    });
+    expect(lastUrl()).toContain("Step%3A%20Review");
+  });
+
+  it("treats blank/whitespace strings as absent", async () => {
+    await openWhatsAppSupport({
+      screen: "configurator",
+      productName: "Classic Suit",
+      fabricName: "   ",
+      stepLabel: "",
+    });
+    const url = lastUrl();
+    expect(url).not.toContain("Fabric");
+    expect(url).not.toContain("Step");
+  });
+});
+
+describe("openWhatsAppSupport — order-detail", () => {
+  it("falls back to the minimal status-only message when no enrichment is provided", async () => {
     await openWhatsAppSupport({
       screen: "order-detail",
       orderId: "abc-123",
       orderStatus: "IN_PRODUCTION",
     });
-
-    expect(Linking.openURL).toHaveBeenCalledWith(
-      expect.stringContaining("order%20%23abc-123"),
-    );
-    expect(Linking.openURL).toHaveBeenCalledWith(
-      expect.stringContaining("IN_PRODUCTION"),
-    );
+    const url = lastUrl();
+    expect(url).toContain("order%20%23abc-123");
+    expect(url).toContain("status%3A%20IN_PRODUCTION");
+    // No descriptor without productName
+    expect(url).not.toContain("%E2%80%94"); // em dash
   });
 
-  it("opens WhatsApp with general context", async () => {
-    (Linking.canOpenURL as jest.Mock).mockResolvedValue(true);
+  it("includes product, fabric, and price when all are present", async () => {
+    await openWhatsAppSupport({
+      screen: "order-detail",
+      orderId: "abc-123",
+      orderStatus: "IN_PRODUCTION",
+      productName: "Classic Suit",
+      fabricName: "Black Wool Crepe",
+      finalPriceCents: 54900,
+    });
+    const url = lastUrl();
+    expect(url).toContain("Classic%20Suit");
+    expect(url).toContain("in%20Black%20Wool%20Crepe");
+    expect(url).toContain("%24549.00"); // $549.00
+    expect(url).toContain("status%3A%20IN_PRODUCTION");
+  });
 
+  it("includes only the product name when fabric and price are absent", async () => {
+    await openWhatsAppSupport({
+      screen: "order-detail",
+      orderId: "abc-123",
+      orderStatus: "IN_PRODUCTION",
+      productName: "Classic Suit",
+    });
+    const url = lastUrl();
+    expect(url).toContain("%E2%80%94%20Classic%20Suit"); // — Classic Suit
+    expect(url).not.toContain("in%20");
+    expect(url).not.toContain("%24"); // no $
+  });
+
+  it("includes product and price without fabric when fabric is absent", async () => {
+    await openWhatsAppSupport({
+      screen: "order-detail",
+      orderId: "abc-123",
+      orderStatus: "IN_PRODUCTION",
+      productName: "Classic Suit",
+      finalPriceCents: 54900,
+    });
+    const url = lastUrl();
+    expect(url).toContain("Classic%20Suit");
+    expect(url).toContain("%24549.00");
+    expect(url).not.toContain("in%20"); // no fabric clause
+  });
+
+  it("omits the descriptor entirely when productName is missing, even if fabric/price are set", async () => {
+    // Negative case: fabric and price alone are ambiguous fragments and
+    // must not leak into the message without a product to anchor them.
+    await openWhatsAppSupport({
+      screen: "order-detail",
+      orderId: "abc-123",
+      orderStatus: "IN_PRODUCTION",
+      fabricName: "Black Wool Crepe",
+      finalPriceCents: 54900,
+    });
+    const url = lastUrl();
+    expect(url).not.toContain("Black%20Wool%20Crepe");
+    expect(url).not.toContain("%24549.00");
+    expect(url).not.toContain("%E2%80%94"); // no em dash
+    // Status clause still present
+    expect(url).toContain("status%3A%20IN_PRODUCTION");
+  });
+
+  it("treats non-finite finalPriceCents as absent", async () => {
+    await openWhatsAppSupport({
+      screen: "order-detail",
+      orderId: "abc-123",
+      orderStatus: "IN_PRODUCTION",
+      productName: "Classic Suit",
+      finalPriceCents: NaN,
+    });
+    const url = lastUrl();
+    expect(url).toContain("Classic%20Suit");
+    expect(url).not.toContain("NaN");
+    expect(url).not.toContain("%24");
+  });
+});
+
+describe("openWhatsAppSupport — general", () => {
+  it("opens WhatsApp with the general message", async () => {
     await openWhatsAppSupport({ screen: "general" });
-
-    expect(Linking.openURL).toHaveBeenCalledWith(
-      expect.stringContaining("question%20about%20my%20order"),
-    );
+    expect(lastUrl()).toContain("question%20about%20my%20order");
   });
 
   it("shows fallback alert when WhatsApp is not installed", async () => {

--- a/src/lib/support.ts
+++ b/src/lib/support.ts
@@ -24,19 +24,69 @@ function getSupportPhone(): string {
 
 /** Context types for building prefilled messages */
 export type SupportContext =
-  | { screen: "configurator"; productName: string }
-  | { screen: "order-detail"; orderId: string; orderStatus: string }
+  | {
+      screen: "configurator";
+      productName: string;
+      // Optional enrichment — included so the tailor immediately sees
+      // which fabric the customer picked and which step they're on.
+      fabricName?: string;
+      stepLabel?: string;
+    }
+  | {
+      screen: "order-detail";
+      orderId: string;
+      orderStatus: string;
+      // Optional enrichment — included so the tailor can answer without
+      // looking the order up. Fabric and price are only meaningful when
+      // anchored by a product name (see buildMessage rules below).
+      productName?: string;
+      fabricName?: string;
+      // Final price in cents (matches orders.final_price unit). Formatted
+      // as `$X.XX` here so callers don't repeat the conversion.
+      finalPriceCents?: number;
+    }
   | { screen: "general" };
+
+// Presence helpers — treat blank strings and non-finite numbers as absent
+// so callers can pass through nullable / fallback values without leaking
+// artefacts like `Fabric: ` or `, $NaN` into the message.
+const presentStr = (v: string | undefined | null): v is string =>
+  typeof v === "string" && v.trim().length > 0;
+const presentNum = (v: number | undefined | null): v is number =>
+  typeof v === "number" && Number.isFinite(v);
 
 /**
  * Build the prefilled WhatsApp message based on the current screen context.
+ *
+ * Optional enrichment fields are appended only when present. The exact
+ * formatting rules live in the issue (#48) and the plan — keeping them
+ * here as code, not comments, so behavioural changes show up in the test
+ * diffs rather than in prose.
  */
 function buildMessage(context: SupportContext): string {
   switch (context.screen) {
-    case "configurator":
-      return `Hi, I have a question about configuring my ${context.productName}`;
-    case "order-detail":
-      return `Hi, I have a question about order #${context.orderId} (status: ${context.orderStatus})`;
+    case "configurator": {
+      const clauses: string[] = [];
+      if (presentStr(context.fabricName))
+        clauses.push(`Fabric: ${context.fabricName.trim()}`);
+      if (presentStr(context.stepLabel))
+        clauses.push(`Step: ${context.stepLabel.trim()}`);
+      const suffix = clauses.length ? ` (${clauses.join(", ")})` : "";
+      return `Hi, I have a question about configuring my ${context.productName}${suffix}`;
+    }
+    case "order-detail": {
+      // Descriptor is anchored by productName — fabric/price alone are
+      // ambiguous fragments without a product to attach them to.
+      let descriptor = "";
+      if (presentStr(context.productName)) {
+        descriptor = ` \u2014 ${context.productName.trim()}`;
+        if (presentStr(context.fabricName))
+          descriptor += ` in ${context.fabricName.trim()}`;
+        if (presentNum(context.finalPriceCents))
+          descriptor += `, $${(context.finalPriceCents / 100).toFixed(2)}`;
+      }
+      return `Hi, I have a question about order #${context.orderId}${descriptor} (status: ${context.orderStatus})`;
+    }
     case "general":
       return "Hi, I have a question about my order";
   }


### PR DESCRIPTION
## Summary

- Configurator FAB message now appends `(Fabric: X, Step: Y)` when those fields are present, and falls back to the original minimal message when they are not.
- Order detail FAB message now includes a ` — Product in Fabric, $price` descriptor between the order ID and status. Descriptor is anchored on `productName` so fabric/price never appear orphaned; each enrichment is independently optional.
- Blank strings and non-finite numbers are treated as absent, so callers can pass nullable join values without leaking `Fabric: ` or `, $NaN` into the message.

## Test plan

- [x] `npm run test:logic` — 128 passing (14 in `support.test.ts` covering both screens, including the negative case where productName is missing but fabric/price are set)
- [x] `npx tsc --noEmit` clean
- [ ] Manual: open configurator, tap FAB, confirm WhatsApp prefill includes Fabric + Step
- [ ] Manual: open a placed order, tap FAB, confirm prefill includes Product, Fabric, Price

Closes #48