### PR TITLE
docs: remove #25 from roadmap (closed as won't-fix)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -527,12 +527,15 @@ These unblock the majority of the feature roadmap.
 6. ~~Home/Profile restructure (#20)~~ ✅ Done. Home is curated storefront, Profile is account dashboard.
 
 **Core features:**
-7. Running price in configurator (#25) — schema change + UI
-8. Push notifications (#21) — requires EAS Build
-9. Broadcast push notifications (#10) — new collections/fabrics announcements
-10. Guided measurements (#23) — important, larger effort
-11. Save full configurations (#22) — extends existing patterns
-12. Restore configurator state from recently viewed (#49) — extend recently viewed store
+7. Push notifications (#21) — requires EAS Build
+8. Broadcast push notifications (#10) — new collections/fabrics announcements
+9. Guided measurements (#23) — important, larger effort
+10. Save full configurations (#22) — extends existing patterns
+11. Restore configurator state from recently viewed (#49) — extend recently viewed store
+
+> Running price in configurator (#25) — closed as won't-fix. Contradicts
+> the "no price anxiety" decision documented in `ReviewSummary.tsx`.
+> `OptionCard` already shows per-option `+$X.XX` upcharges inline.
 
 **Medium effort:**
 13. Post-delivery fit check (#24)


### PR DESCRIPTION
## Summary

- Removes #25 (Running price total in configurator) from the active roadmap in CLAUDE.md.
- Adds a short note explaining why so it doesn't get re-proposed.
- #25 closed on GitHub with the same reasoning — contradicts the no-price-anxiety decision documented in `src/features/configurator/components/ReviewSummary.tsx`, and `OptionCard` already shows per-option upcharges inline.

## Test plan

- [x] Documentation-only — no code changes